### PR TITLE
録音対象の選定結果をログ出力する

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ go run main.go
 |--------------------|------|-------------------------------------------|
 | CALENDAR_ID        | 必須 | 対象GoogleカレンダーのID                  |
 | RUN_AFTER_MINUTES  | 任意 | 終了後何分経過したイベントを対象にするか   |
+| LOG_LEVEL          | 任意 | `debug`でスキップ理由・スクリプト出力も出力（既定は通常ログ） |
+
+---
+
+## ログ出力
+
+実行のたびに、`[calsrecoil]` タグ付きで以下を標準エラー出力（journaldで集約可能）に出力します。
+
+```
+[calsrecoil] 実行開始: calendar取得=5件 対象=1件 window(終了時刻)=2026-07-08T10:10:00+09:00〜2026-07-15T09:40:00+09:00 run_after=30min
+[calsrecoil] 対象: summary="XXXラジオ" station=TBS time=2026-07-15T10:00:00+09:00〜2026-07-15T10:30:00+09:00
+[calsrecoil] 実行: summary="XXXラジオ" station=TBS scriptを起動
+[calsrecoil] 完了: summary="XXXラジオ" exit=0
+[calsrecoil] 実行完了: 対象=1件 成功=1 失敗=0
+```
+
+- `window(終了時刻)` は選定に使った時間窓で、**イベントの終了時刻**が下限（1週間前）〜上限（`now - RUN_AFTER_MINUTES`）に収まる予定が対象です。
+- 個人情報保護の方針により、`CALENDAR_ID` はログに出力しません。
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/api/option"
@@ -24,7 +26,28 @@ const (
 	successTag = "🆗"
 	failureTag = "🆖"
 	maxRetries = 5
+	logTag     = "[calsrecoil]"
 )
+
+// logInfo はjournaldで拾えるよう、統一タグ付きでstderrにログ出力する。
+// 個人情報保護の観点から、CALENDAR_ID はここに渡さないこと。
+func logInfo(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, logTag+" "+format+"\n", a...)
+}
+
+// eventTime はイベントの日時（DateTime優先、終日イベントはDate）を返す。
+func eventTime(dt *calendar.EventDateTime) string {
+	if dt == nil {
+		return "?"
+	}
+	if dt.DateTime != "" {
+		return dt.DateTime
+	}
+	if dt.Date != "" {
+		return dt.Date
+	}
+	return "?"
+}
 
 func main() {
 	calendarID, ok := os.LookupEnv("CALENDAR_ID") // 環境変数からカレンダーIDを取得
@@ -38,6 +61,10 @@ func main() {
 		log.Printf("Invalid RUN_AFTER_MINUTES value: %v, set to 0", err)
 		runAfterMinutes = 0
 	}
+
+	// LOG_LEVEL=debug のときは詳細（スキップ理由・スクリプト出力）も出す。
+	// 未指定/その他は通常ログ（サマリ・対象・実行結果）のみ。
+	debug := strings.EqualFold(os.Getenv("LOG_LEVEL"), "debug")
 
 	ctx := context.Background()
 	execPath, err := os.Executable()
@@ -71,6 +98,11 @@ func main() {
 		log.Fatalf("Unable to retrieve events: %v", err)
 	}
 
+	// 選定に使う時間窓（イベントの終了時刻ベース）
+	// 下限: 1週間前 / 上限: now - RUN_AFTER_MINUTES（終了後この分数だけ経過した予定が対象）
+	windowStart := weekAgo
+	windowEnd := now.Add(-1 * time.Duration(runAfterMinutes) * time.Minute)
+
 	// 条件に合うイベントをフィルタ
 	var targets []*calendar.Event
 	for _, item := range events.Items {
@@ -99,14 +131,28 @@ func main() {
 			continue
 		}
 		if strings.Count(item.Summary, failureTag) >= maxRetries {
-			log.Printf("Skipped: %s, already retried %d times", item.Summary, maxRetries)
+			if debug {
+				logInfo("スキップ: summary=%q リトライ上限(%d回)到達", item.Summary, maxRetries)
+			}
 			continue
 		}
 		targets = append(targets, item)
 	}
 
+	// 実行サマリ: 取得件数・対象件数・選定窓・run_after を出力（CALENDAR_IDは出さない）
+	logInfo("実行開始: calendar取得=%d件 対象=%d件 window(終了時刻)=%s〜%s run_after=%dmin",
+		len(events.Items), len(targets),
+		windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339), runAfterMinutes)
+
+	// 対象と判定した予定を1件ずつ出力
+	for _, ev := range targets {
+		logInfo("対象: summary=%q station=%s time=%s〜%s",
+			ev.Summary, ev.Location, eventTime(ev.Start), eventTime(ev.End))
+	}
+
 	// 並行実行
 	var wg sync.WaitGroup
+	var successCount, failureCount atomic.Int32
 	for _, ev := range targets {
 		wg.Add(1)
 		go func(event *calendar.Event) {
@@ -115,17 +161,27 @@ func main() {
 			cleanedSummary := strings.ReplaceAll(event.Summary, failureTag, "")
 			cleanedSummary = strings.ReplaceAll(cleanedSummary, successTag, "")
 			cleanedSummary = strings.TrimSpace(cleanedSummary)
-			fmt.Printf("Executing title: %s\n", event.Summary)
+			logInfo("実行: summary=%q station=%s scriptを起動", cleanedSummary, event.Location)
 			cmd := exec.Command(scriptFullPath, event.Start.DateTime, event.End.DateTime, cleanedSummary, event.Location, event.Description)
 			out, err := cmd.CombinedOutput()
-			fmt.Printf("log for %s: %s\n", event.Summary, string(out))
+			// スクリプト出力はdebug時、または失敗時のみ出力（通常時のノイズ抑制）
+			if debug || err != nil {
+				fmt.Printf("log for %s: %s\n", event.Summary, string(out))
+			}
 			var tag string
 			if err == nil {
 				tag = successTag
-				log.Printf("Success: %s", event.Summary)
+				successCount.Add(1)
+				logInfo("完了: summary=%q exit=0", cleanedSummary)
 			} else {
 				tag = failureTag
-				log.Printf("Failed: %s, err: %v", event.Summary, err)
+				failureCount.Add(1)
+				exitCode := -1
+				var ee *exec.ExitError
+				if errors.As(err, &ee) {
+					exitCode = ee.ExitCode()
+				}
+				logInfo("失敗: summary=%q exit=%d err=%v", cleanedSummary, exitCode, err)
 			}
 
 			// description追記
@@ -141,5 +197,6 @@ func main() {
 		}(ev)
 	}
 	wg.Wait()
-	log.Println("All done.")
+	logInfo("実行完了: 対象=%d件 成功=%d 失敗=%d",
+		len(targets), successCount.Load(), failureCount.Load())
 }


### PR DESCRIPTION
## 背景 / 課題

Googleカレンダー連動でradikoを録音する運用（systemdタイマーで毎時実行）で、「番組のダウンロードが遅い・録音されないことがある」事象の原因切り分けをしたい。しかし、カレンダーのどの予定が録音対象として選ばれたのかがログから分からなかった。

呼び出し側（録音スクリプト）のログだけでは calsrecoil がスクリプトを呼んだ分しか追えないため、calsrecoil 本体で選定結果をログ出力する。

## やったこと

`[calsrecoil]` タグ付きで stderr（journald で集約可能）に以下を出力する。

```
[calsrecoil] 実行開始: calendar取得=5件 対象=1件 window(終了時刻)=2026-07-08T10:10:00+09:00〜2026-07-15T09:40:00+09:00 run_after=30min
[calsrecoil] 対象: summary="XXXラジオ" station=TBS time=2026-07-15T10:00:00+09:00〜2026-07-15T10:30:00+09:00
[calsrecoil] 実行: summary="XXXラジオ" station=TBS scriptを起動
[calsrecoil] 完了: summary="XXXラジオ" exit=0
[calsrecoil] 実行完了: 対象=1件 成功=1 失敗=0
```

- 実行サマリ: calendar取得件数・録音対象件数・選定窓・`run_after`
- 対象ごとに1行: タイトル・開始/終了時刻・station(location)
- スクリプト起動と終了コード（`exec.ExitError` から実際の exit code を取得）
- `LOG_LEVEL=debug` でスキップ理由・スクリプト標準出力も表示（既定は失敗時のみスクリプト出力）
- **個人情報保護方針により `CALENDAR_ID` はログに出力しない**

## 受け入れ条件

- [x] 実行のたびに「取得件数」と「対象件数」が分かる
- [x] 録音対象と判定した予定ごとに、タイトル・時刻・location が分かる
- [x] 選定に使った時間窓（now と RUN_AFTER_MINUTES から算出した範囲）が分かる

## 補足: 選定窓の実態

`RUN_AFTER_MINUTES` は「終了後この分数だけ待ってから対象にする**猶予**」として効いており、対象は「終了時刻が下限(1週間前)〜上限(`now - RUN_AFTER_MINUTES`)に収まる予定」。毎時 :10 実行・30分猶予だと、10:00終了の番組は10:10実行ではスキップされ、次の11:10実行で初めて対象になる（最大1時間強の遅延）。この window をログに出すことで遅延の切り分けが可能になる。選定ロジック自体の変更は本PRのスコープ外。

## 動作確認

- `go build ./...` / `go vet ./...` / `gofmt -l` すべてクリーン